### PR TITLE
Fix: NullPointException

### DIFF
--- a/android/src/main/java/com/example/logcat_monitor/LogcatMonitorPlugin.java
+++ b/android/src/main/java/com/example/logcat_monitor/LogcatMonitorPlugin.java
@@ -159,7 +159,9 @@ public class LogcatMonitorPlugin implements FlutterPlugin, MethodCallHandler, Ev
 				new Runnable() {
 					@Override
 					public void run() {
-						eventSink.success(message);
+						if (eventSink != null) {
+							eventSink.success(message);
+						}
 					}
 				});
 	}


### PR DESCRIPTION
The sendEvent method is often called after the clearListener is called.
At this point, the event sink will be null followed by a crash.